### PR TITLE
Fix lint and revert pyproject.toml

### DIFF
--- a/libs/langchain/langchain/chat_models/azure_openai.py
+++ b/libs/langchain/langchain/chat_models/azure_openai.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 import logging
 import os
 import warnings
-from typing import Any, Dict, Union
+from typing import Any, Dict, Optional, Union
 
 from langchain.chat_models.openai import ChatOpenAI
-from langchain.pydantic_v1 import BaseModel, Field, root_validator
+from langchain.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain.schema import ChatResult
 from langchain.utils import get_from_dict_or_env
 from langchain.utils.openai import is_openai_v1
@@ -69,7 +69,7 @@ class AzureChatOpenAI(ChatOpenAI):
     """
     openai_api_version: str = Field(default="", alias="api_version")
     """Automatically inferred from env var `OPENAI_API_VERSION` if not provided."""
-    openai_api_key: Union[str, None] = Field(default=None, alias="api_key")
+    openai_api_key: Optional[SecretStr] = Field(default=None, alias="api_key")
     """Automatically inferred from env var `AZURE_OPENAI_API_KEY` if not provided."""
     azure_ad_token: Union[str, None] = None
     """Your Azure Active Directory token.

--- a/libs/langchain/langchain/chat_models/openai.py
+++ b/libs/langchain/langchain/chat_models/openai.py
@@ -31,7 +31,7 @@ from langchain.chat_models.base import (
     _generate_from_stream,
 )
 from langchain.llms.base import create_base_retry_decorator
-from langchain.pydantic_v1 import BaseModel, Field, root_validator, SecretStr
+from langchain.pydantic_v1 import BaseModel, Field, SecretStr, root_validator
 from langchain.schema import ChatGeneration, ChatResult
 from langchain.schema.language_model import LanguageModelInput
 from langchain.schema.messages import (
@@ -47,9 +47,9 @@ from langchain.schema.messages import (
 from langchain.schema.output import ChatGenerationChunk
 from langchain.schema.runnable import Runnable
 from langchain.utils import (
+    convert_to_secret_str,
     get_from_dict_or_env,
     get_pydantic_field_names,
-    convert_to_secret_str,
 )
 from langchain.utils.openai import is_openai_v1
 
@@ -271,9 +271,7 @@ class ChatOpenAI(BaseChatModel):
             raise ValueError("n must be 1 when streaming.")
 
         values["openai_api_key"] = convert_to_secret_str(
-            get_from_dict_or_env(
-                values, "openai_api_key", "OPENAI_API_KEY"
-            )
+            get_from_dict_or_env(values, "openai_api_key", "OPENAI_API_KEY")
         )
         # Check OPENAI_ORGANIZATION for backwards compatibility.
         values["openai_organization"] = (

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -212,6 +212,7 @@ optional = true
 jupyter = "^1.0.0"
 playwright = "^1.28.0"
 setuptools = "^67.6.1"
+hypothesis = "^6.90.0"
 
 [tool.poetry.extras]
 llms = ["clarifai", "cohere", "openai", "openlm", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]
@@ -409,7 +410,7 @@ build-backend = "poetry.core.masonry.api"
 #
 # https://github.com/tophat/syrupy
 # --snapshot-warn-unused    Prints a warning on unused snapshots rather than fail the test suite.
-addopts = "--strict-markers --strict-config --durations=5 -vv"
+addopts = "--strict-markers --strict-config --durations=5 --snapshot-warn-unused -vv"
 # Registering custom markers.
 # https://docs.pytest.org/en/7.1.x/example/markers.html#registering-markers
 markers = [

--- a/libs/langchain/pyproject.toml
+++ b/libs/langchain/pyproject.toml
@@ -212,7 +212,6 @@ optional = true
 jupyter = "^1.0.0"
 playwright = "^1.28.0"
 setuptools = "^67.6.1"
-hypothesis = "^6.90.0"
 
 [tool.poetry.extras]
 llms = ["clarifai", "cohere", "openai", "openlm", "nlpcloud", "huggingface_hub", "manifest-ml", "torch", "transformers"]

--- a/libs/langchain/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/langchain/tests/unit_tests/chat_models/test_openai.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pytest import CaptureFixture, MonkeyPatch
 
-from langchain.pydantic_v1 import SecretStr
 from langchain.adapters.openai import convert_dict_to_message
 from langchain.chat_models.openai import ChatOpenAI
+from langchain.pydantic_v1 import SecretStr
 from langchain.schema.messages import (
     AIMessage,
     FunctionMessage,
@@ -126,6 +126,8 @@ async def test_openai_apredict(mock_completion: dict) -> None:
 
 
 """Test Openai chat model"""
+
+
 @pytest.mark.requires("openai")
 def test_api_key_is_secret_string() -> None:
     llm = ChatOpenAI(


### PR DESCRIPTION
This PR:
- Fixes the formatting pointed out by the lint check.
- Reverts the pyproject.toml to as it was upstream.
- Changes the AsureChatOpenAI class's OpenAI_api_key to expect SecretStr since it is derived from the OpenAI class and is expecting a str but instead gets SecretStr. As it is highlighted [here ](https://github.com/langchain-ai/langchain/commit/b376854b268d276b254213c382e6b0d241ec1583)